### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </scm>
   <properties>
     <java.version>11</java.version>
-    <activiti-cloud-dependencies.version>7.1.20</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.1.21</activiti-cloud-dependencies.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.21`