### PR TITLE
fix: change Notfications service ingress base path to /notifications

### DIFF
--- a/charts/activiti-cloud-notifications-graphql/templates/deployment.yaml
+++ b/charts/activiti-cloud-notifications-graphql/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
           value: "false"
         - name: ACT_CLOUD_CONFIG_SERVER_ENABLED
           value: "false"
+        - name: SERVER_SERVLET_CONTEXTPATH
+          value: {{ tpl .Values.ingress.path . | quote }}
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 8 }}
 {{- end }}
@@ -78,7 +80,7 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . | quote }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -87,7 +89,7 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ tpl .Values.probePath . | quote }}
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}  
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
+++ b/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
@@ -9,18 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- include "kubernetes.io/tls-acme" . | indent 4}} 
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*" 
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,PUT,POST,DELETE,PATCH,OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"   
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
-    nginx.ingress.kubernetes.io/affinity: cookie
-    nginx.ingress.kubernetes.io/session-cookie-name: "activiti-cloud-notifications-graphql-route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "md5"
-    nginx.ingress.kubernetes.io/session-cookie-path: "/"
     {{- range $key, $value := .Values.global.gateway.annotations }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}

--- a/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
+++ b/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
@@ -21,6 +21,12 @@ spec:
     - host: {{ include "ingresshost" $ | quote }}
       http:
         paths:
+        {{- if .Values.ingress.actuator.enabled }}
+        - path: {{ tpl .Values.ingress.path . }}{{ .Values.ingress.actuator.path }}
+          backend:
+            serviceName: {{ template "servicename" . }}
+            servicePort: {{ .Values.service.externalPort }}
+        {{- end }}
         {{- if .Values.ingress.web.enabled }}
         - path: {{ tpl .Values.ingress.path . }}{{ .Values.ingress.web.path }}
           backend:

--- a/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
+++ b/charts/activiti-cloud-notifications-graphql/templates/ingress.yaml
@@ -29,23 +29,23 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ include "ingresshost" $ }}
+    - host: {{ include "ingresshost" $ | quote }}
       http:
         paths:
         {{- if .Values.ingress.web.enabled }}
-        - path: {{ .Values.ingress.web.path }}
+        - path: {{ tpl .Values.ingress.path . }}{{ .Values.ingress.web.path }}
           backend:
             serviceName: {{ template "servicename" . }}
             servicePort: {{ .Values.service.externalPort }}
         {{- end }}
         {{- if .Values.ingress.ws.enabled }}
-        - path: {{ .Values.ingress.ws.path }}
+        - path: {{ tpl .Values.ingress.path . }}{{ .Values.ingress.ws.path }}
           backend:
             serviceName: {{ template "servicename" . }}
             servicePort: {{ .Values.service.externalPort }}
         {{- end }}
         {{- if .Values.ingress.graphiql.enabled }}
-        - path: {{ .Values.ingress.graphiql.path }}
+        - path: {{ tpl .Values.ingress.path . }}{{ .Values.ingress.graphiql.path }}
           backend:
             serviceName: {{ template "servicename" . }}
             servicePort: {{ .Values.service.externalPort }}

--- a/charts/activiti-cloud-notifications-graphql/values.yaml
+++ b/charts/activiti-cloud-notifications-graphql/values.yaml
@@ -71,24 +71,25 @@ resources:
   requests:
     cpu: "200m"
     memory: 512Mi
-probePath: /actuator/health
+probePath: '{{ .Values.ingress.path }}/actuator/health'
 livenessProbe:
   initialDelaySeconds: 140
   periodSeconds: 15
   timeoutSeconds: 20
   successThreshold: 1
-  failureThreshold: 40
+  failureThreshold: 3
 readinessProbe:
   initialDelaySeconds: 20
   periodSeconds: 15
   timeoutSeconds: 5
   successThreshold: 1
-  failureThreshold: 80
+  failureThreshold: 3
 terminationGracePeriodSeconds: 20
 
 ingress:
   ## Set to true to enable ingress record generation
   enabled: true
+  path: /notifications
   tls: # overrides .Values.global.gateway.tls  
   tlsSecret: # overrides .Values.global.gateway.tlsSecret  
   hostName: # overrides .Values.global.gateway.host

--- a/charts/activiti-cloud-notifications-graphql/values.yaml
+++ b/charts/activiti-cloud-notifications-graphql/values.yaml
@@ -102,6 +102,19 @@ ingress:
   ws: 
     enabled: true
     path: /ws/graphql
-  annotations: {} 
+  annotations: 
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET,PUT,POST,DELETE,PATCH,OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"   
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-name: "activiti-cloud-notifications-graphql-route"
+    nginx.ingress.kubernetes.io/session-cookie-hash: "md5"
+    nginx.ingress.kubernetes.io/session-cookie-path: "{{ .Values.ingress.path }}"
+  
 
     

--- a/charts/activiti-cloud-notifications-graphql/values.yaml
+++ b/charts/activiti-cloud-notifications-graphql/values.yaml
@@ -93,6 +93,9 @@ ingress:
   tls: # overrides .Values.global.gateway.tls  
   tlsSecret: # overrides .Values.global.gateway.tlsSecret  
   hostName: # overrides .Values.global.gateway.host
+  actuator: 
+    enabled: true
+    path: /actuator
   graphiql: 
     enabled: true
     path: /graphiql


### PR DESCRIPTION
This PR updates base ingress path of the Notifications service to `/notifications`

Part of https://github.com/Activiti/Activiti/issues/2720