### PR TITLE
refactor(build): changed base Docker image to adoptopenjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM adoptopenjdk/openjdk11:jdk-11.0.2.7-alpine-slim
-FROM openjdk:11.0.1-jre-slim-stretch
+FROM adoptopenjdk/openjdk11:jdk-11.0.2.7-alpine-slim
 ENV PORT 8080	
 EXPOSE 8080	
 COPY target/*.jar /opt/app.jar	


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-notifications-service-graphql/pull/137

Fixes https://github.com/Activiti/Activiti/issues/1399