### PR TITLE
fix(versions): update Activiti/activiti-cloud-notifications-graphql versions

### DIFF
--- a/charts/activiti-cloud-notifications-graphql/requirements.yaml
+++ b/charts/activiti-cloud-notifications-graphql/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "1.1.29"
+  version: "1.1.30"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `common` to: `1.1.30`